### PR TITLE
More cleanups

### DIFF
--- a/encoding/README.md
+++ b/encoding/README.md
@@ -1,3 +1,10 @@
+Encoding and queue management
+=============================
+q-mgr.py     - Used to parse schedule data, mark start/end cuts, and create encode jobs
+q-run.py     - Used to execute encode jobs
+gen_image.pl - Creates a text based png for titles and credits in videos
+
+
 youtube uploader
 ================
 

--- a/encoding/lib/duration.py
+++ b/encoding/lib/duration.py
@@ -13,7 +13,7 @@ def get_duration(filename):
 def str2delta(raw):
     formats = ["%H:%M:%S", "%H:%M:%S.%f", "%M:%S", "%M:%S.%f", "%S", "%S.%f"]
     time = None
-    zero = datetime.datetime.strptime("00:00", "%M:%S")
+    zero = datetime.datetime.strptime("", "")
     for f in formats:
         try:
             time = datetime.datetime.strptime(raw, f) - zero

--- a/encoding/q-mgr.py
+++ b/encoding/q-mgr.py
@@ -68,18 +68,15 @@ while n:
     while end_offset is None:
         end_offset = prompt_for_time("End time offset")
 
-    print
-    # this basically prints the cut list which will be used later
+    # this sets up the cut_list which will be used later
     talk['cut_list'] = talk['playlist'][start_file:end_file+1]
-    print talk['cut_list']
     talk['cut_list'][0]['in'] = start_offset
     talk['cut_list'][-1]['out'] = end_offset
-    print talk['cut_list']
-
 
     print "Creating and queuing job " + str(talk['schedule_id'])
-    create_mlt(talk, os.path.join(queue_todo_dir, str(talk['schedule_id']) + '.mlt'))
-    create_title(talk, os.path.join(queue_todo_dir, str(talk['schedule_id']) + '.title.png'))
+    job_file = os.path.join(queue_todo_dir, str(talk['schedule_id']))
+    create_mlt(talk, job_file + '.mlt')
+    create_title(talk, job_file + '.title.png')
 
     print
     print "----------"


### PR DESCRIPTION
- Update README with information about q-mgr.py and q-run.py
- Change zero to refer to the empty parse of strptime
- Remove unnecessary prints
