### PR TITLE
PROBLEM - Unsort dvfile playlist that prevented me from selecting an end...

### DIFF
--- a/encoding/lib/schedule.py
+++ b/encoding/lib/schedule.py
@@ -51,3 +51,4 @@ def link_dv_files(talk, recording_root, dv_match_window, dv_format):
                     'filepath' : talk_path
                 }
                 talk['playlist'].append(dv_file)
+                talk['playlist'].sort()


### PR DESCRIPTION
... file with a sequence of files in order.

Solution - Sort the list where it was created in lib/schedule.py link_dv_files
