### PR TITLE
Various Fixes to MLT Output

### DIFF
--- a/encoding/lib/job.py
+++ b/encoding/lib/job.py
@@ -1,49 +1,32 @@
 import os
 import subprocess
 
-from xml.etree.ElementTree import Element, SubElement, Comment, tostring
-from xml.etree import ElementTree
-from xml.dom import minidom
+from lxml.etree import ElementTree, Element, SubElement
 
-def prettify(elem):
-    """Return a pretty-printed XML string for the Element.
-    """
-    rough_string = ElementTree.tostring(elem, 'utf-8')
-    reparsed = minidom.parseString(rough_string)
-    return reparsed.toprettyxml(indent="  ")
-
-def create_mlt(talk, output_file):
+def create_mlt(talk, output_file, dv_frame_rate):
     mlt = Element('mlt')
+    playlist = Element("playlist", id="playlist0")
     for cut_file in talk["cut_list"]:
+        # Create the producer
         producer = SubElement(mlt, 'producer', id=cut_file["filename"])
         producer_property = SubElement(producer, "property", name="resource")
-        producer_property.text = cut_file["filepath"] + "/" + cut_file["filename"]
+        producer_property.text = os.path.join(cut_file["filepath"],cut_file["filename"])
 
-    playlist = SubElement(mlt, "playlist", id="playlist0")
-
-
-
-    for cut_file in talk["cut_list"]:
-#        print cut_file
+        # Create the playlist entry
         args = {}
         args['producer'] = cut_file['filename']
-        print cut_file
+        # Check if we have any cuts, and calculate the appropriate frame
         if 'in' in cut_file and cut_file['in']:
-            args['in'] = str(int(cut_file['in'].total_seconds()) * 25)
-            playlist_entry = SubElement(playlist, "entry", args)
+            args['in'] = str(int(cut_file['in'].total_seconds()) * dv_frame_rate)
         if 'out' in cut_file and cut_file['out']:
-            args['out'] = str(int(cut_file['out'].total_seconds()) * 25)
-            playlist_entry = SubElement(playlist, "entry", args)
-        if 'in' not in cut_file and 'out' not in cut_file:
-            playlist_entry = SubElement(playlist, "entry", args)
+            args['out'] = str(int(cut_file['out'].total_seconds()) * dv_frame_rate)
+        playlist_entry = SubElement(playlist, "entry", args)
 
-    print prettify(mlt)
+    # The playlist must be after the producers
+    mlt.append(playlist)
 
-    main_file = open(output_file, "w")
-    main_file.write(prettify(mlt));
-    main_file.close()
-    #ElementTree.ElementTree(prettify(mlt)).write(output_file)
-
+    # Write out the tree
+    ElementTree(mlt).write(output_file, pretty_print=True)
 
 def create_title(talk, output_file):
     with open(os.devnull, 'wb') as DEVNULL:

--- a/encoding/lib/schedule.py
+++ b/encoding/lib/schedule.py
@@ -40,11 +40,11 @@ def get_schedule(schedule_file, json_format):
     return talks
 
 def link_dv_files(talk, recording_root, dv_match_window, dv_format):
-    talk['playlist'] = [] 
+    talk['playlist'] = []
     talk_path = os.path.join(recording_root, talk['room'], talk['date'])
     if os.path.exists(talk_path):
         for filename in os.listdir(talk_path):
-            time = dv_to_datetime(filename, dv_format) 
+            time = dv_to_datetime(filename, dv_format)
             if time and talk['start'] - dv_match_window <= time <= talk['end'] + dv_match_window:
                 dv_file = {
                     'filename' : filename,

--- a/encoding/q-mgr.py
+++ b/encoding/q-mgr.py
@@ -29,6 +29,7 @@ json_format="%Y-%m-%d %H:%M:%S"
 
 dv_format="%Y-%m-%d_%H-%M-%S"
 dv_match_window = datetime.timedelta(minutes=10)
+dv_frame_rate = 25
 
 # Load the schedule
 talks = get_schedule(schedule_file, json_format)
@@ -75,7 +76,7 @@ while n:
 
     print "Creating and queuing job " + str(talk['schedule_id'])
     job_file = os.path.join(queue_todo_dir, str(talk['schedule_id']))
-    create_mlt(talk, job_file + '.mlt')
+    create_mlt(talk, job_file + '.mlt', dv_frame_rate)
     create_title(talk, job_file + '.title.png')
 
     print


### PR DESCRIPTION
- Remove unnecessary whitespace
- Revert to previous version of job.py
- Get rid of static DV frame rate in job.py
- Switch to lxml
- Append the playlist element to the mlt element once the producers have been created
