### PR TITLE
Add upstart job for twistd, based on station-mgr job.

### DIFF
--- a/baseimage/configure-host.sh
+++ b/baseimage/configure-host.sh
@@ -192,6 +192,7 @@ sed -i "s/${existing}/${hostname}/g" /etc/hostname
 
 echo "- updating /etc/rc.local to start eventstreamr bits"
 cp $IMAGE/upstart/station-mgr.conf /etc/init/station-mgr.conf
+cp $IMAGE/upstart/station-mgr.conf /etc/init/conf-mgr.conf
 
 echo "- fix grub"
 /usr/sbin/grub-install /dev/sda

--- a/baseimage/upstart/conf-mgr.conf
+++ b/baseimage/upstart/conf-mgr.conf
@@ -1,0 +1,10 @@
+# Upstart file /etc/init/conf-mgr.conf
+ 
+respawn limit 1 5
+ 
+start on runlevel [2345]
+stop on runlevel [016]
+ 
+script
+    su - av -c "cd /home/av/eventstreamr/conf-mgr && twistd --pidfile station.pid --nodaemon --python station.py"
+end script


### PR DESCRIPTION
It's nice for twistd not to die automatically during an encode-fest. C.f. commit message.
